### PR TITLE
Fixed link to travis ci build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/zalando-stups/white-fennec.svg?branch=master)](https://travis-ci.org/zalando-stups/white-fennec)
+[![Build Status](https://travis-ci.org/zalando-incubator/white-fennec.svg?branch=master)](https://travis-ci.org/zalando-incubator/white-fennec)
 # white-fennec
 
 white-fennec use [mai](https://github.com/zalando-stups/mai) to show a list of available accounts for AWS.


### PR DESCRIPTION
fix link to travis after moving the repo